### PR TITLE
chore: 升级 TypeScript 至 6.0.3 并归档升级记录

### DIFF
--- a/docs/typescript-upgrade/README.md
+++ b/docs/typescript-upgrade/README.md
@@ -1,0 +1,19 @@
+# TypeScript 升级归档
+
+本文件夹归档 `crm-admin` 的 TypeScript 版本升级记录，供下次升级参考，避免污染仓库根目录。
+
+## 文件
+
+- [ts7-upgrade-baseline.md](./ts7-upgrade-baseline.md) — 升级前性能基准 + 实际升级结果记录（含 6.0.3 / 7.0.2 实测数据）。
+- [ts7-upgrade-todo.md](./ts7-upgrade-todo.md) — 分阶段（Phase 0–5）+ Gate 关卡的升级 checklist，含「升级受阻日志」。
+
+## 当前状态（2026-07-13）
+
+- **TS 版本**：`5.8.3` → **`6.0.3`**（落在 `ts-upgrade` 分支）。
+- **7.0 进度**：TS 7.0.2 已验证 typecheck / `tsc -b` 均 0 错，但 **typescript-eslint 尚不支持 TS 7.0**（[typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)），故暂停于 6.0.3。
+- **6.0.3 验证**：typecheck 0 错、lint 0 错、`pnpm build` exit 0、`pnpm dev` HTTP 200、pre-commit（tsc-files）OK。
+- **下次升级**：待 typescript-eslint 发版支持 TS 7.0 后，按 todo 文档续做 Phase 2–5（6.0.3→7.0.2 已在 Gate 2 验证 0 错）。
+
+## 通用方法论
+
+更通用的「TS 性能检测方案」方法论（关注指标 / 工具 / 注意事项 / 制定方案 / React·Vue·Node·Monorepo 场景）见 Obsidian 笔记：`笔记本/Evernote/TypeScript/性能检测方案.md`。

--- a/docs/typescript-upgrade/ts7-upgrade-baseline.md
+++ b/docs/typescript-upgrade/ts7-upgrade-baseline.md
@@ -1,0 +1,94 @@
+# TypeScript 7.0 升级 — 性能基准（升级前）
+
+> 用于对比升级到 TS 7.0（Go 原生编译器）前后的性能差异。**升级后请用相同方法、相同 commit、相同机器复测，填入“升级后”列。**
+
+## 环境快照
+
+| 项 | 值 |
+|---|---|
+| TypeScript | 5.8.3 |
+| Node.js | v20.19.0 |
+| 机器 | AMD Ryzen 7 8745HS / 31.3 GB RAM / Windows 11 |
+| 分支 / commit | develop |
+| 计时工具 | bash `time`（`TIMEFORMAT='%R'`，hyperfine 未安装） |
+| 测量日期 | 2026-07-13 |
+
+## 基准数据
+
+| 指标 | 升级前（中位数） | 升级前（明细） | 升级后 |
+|---|---|---|---|
+| **`tsc --noEmit`**（全量类型检查，无缓存） | **22.49s** | 21.19 / 22.31 / 22.49 / 22.98 / 24.24（5 轮） | _待测_ |
+| **`tsc -b`** 冷启动（无 tsbuildinfo） | **27.05s** | 单次 | _待测_ |
+| **`tsc -b`** 热启动（incremental，无改动） | **23.27s** | 22.54 / 23.27 / 24.67（3 轮） | _待测_ |
+| **`pnpm build`** 冷启动（`tsc -b && vite build`） | **39.31s** | 单次 | _待测_ |
+| `vite build` 单独（参照，不受 TS 版本影响） | 14.25s | 单次 | _预期不变_ |
+| 类型错误数 | **0**（exit 0） | — | _应保持 0_ |
+
+> 计时方式：`tsc --noEmit` 先跑 1 次未计时的 warmup 预热 OS 文件缓存，再跑 5 轮取中位数；`tsc -b` 热启动跑 3 轮取中位数；冷启动 / 全量构建为单次（冷启动天然单次）。均用本地 `pnpm exec tsc`，已避开 husky / lint-staged 干扰。
+
+## 关键观察
+
+1. **类型检查占总构建约 69%**：`tsc -b` 冷 27.05s 占 `pnpm build` 39.31s 的约 69%，vite 占约 31%。TS 类型检查正是 TS 7.0 加速的部分。
+2. **incremental 缓存当前几乎无效**：`tsc -b` 热（23.27s）≈ 冷（27.05s）。原因是根 `tsconfig.json` 没有拆成 composite 项目引用（`references: []`），即使是“热”也几乎做全量检查。
+   - 推论：TS 7.0 的全量加速对“冷”和“热”都应近乎等比例生效（热启动不会因为缓存而吃掉提速）。
+3. **类型错误数为 0**：基准是干净的，升级后若错误数变化说明 TS 7.0 在诊断层面有差异（质量信号，非性能）。
+
+## 升级后预期（按 Microsoft 宣传的 ~10× 估算）
+
+| 指标 | 升级前 | 预期（10×） |
+|---|---|---|
+| `tsc --noEmit` | 22.49s | ~2.3s |
+| `tsc -b` 冷 | 27.05s | ~2.7s |
+| `pnpm build` 冷 | 39.31s | ~17s（vite 14.25s + tsc ~2.7s） |
+
+> 注意：10× 是 Microsoft 对大型项目的宣传口径，本项目实际倍率以升级后实测为准。
+
+## 复测方法（升级后照此执行）
+
+```bash
+export TIMEFORMAT='%R'
+
+# 1. 全量类型检查（主指标，5 轮取中位数）
+pnpm exec tsc --noEmit >/dev/null 2>&1   # warmup
+for i in 1 2 3 4 5; do e=$( { time pnpm exec tsc --noEmit >/dev/null 2>&1 ; } 2>&1 ); echo "run $i: ${e}s"; done
+
+# 2. 增量构建 冷 + 热
+find . -maxdepth 2 -name "*.tsbuildinfo" -not -path "*/node_modules/*" -delete
+{ time pnpm exec tsc -b >/dev/null 2>&1 ; } 2>&1   # 冷
+for i in 1 2 3; do e=$( { time pnpm exec tsc -b >/dev/null 2>&1 ; } 2>&1 ); echo "warm $i: ${e}s"; done
+
+# 3. 端到端
+find . -maxdepth 2 -name "*.tsbuildinfo" -not -path "*/node_modules/*" -delete
+{ time pnpm build >/dev/null 2>&1 ; } 2>&1
+```
+
+## 升级结果记录（2026-07-13）
+
+**结论：暂停于 TS 6.0.3。** TS 7.0 本身验证通过，但 lint 工具链（typescript-eslint）尚未支持 7.0。
+
+### TS 6.0.3（当前落点）实测
+
+| 指标 | 5.8.3 基线 | 6.0.3 | 变化 |
+|---|---|---|---|
+| `tsc --noEmit` 中位数 | 22.49s | 20.66s（20.39 / 20.66 / 20.93） | **-8%** |
+| 类型错误数 | 0 | 0 | — |
+| `pnpm lint` | 0 error（36 warn） | 0 error（36 warn） | — |
+| `tsc-files`（pre-commit） | OK | OK | — |
+| `pnpm build` 冷 | 39.31s | 40s | 持平 |
+
+- 6.0.3 改动：移除 `baseUrl`、`i18n.ts` `process.env`→`import.meta.env.DEV`、typescript-eslint `8.30.1`→`8.63.0`。
+- ~8% 提升来自 6.0 新默认 `types: []`（不再无脑加载全部 `@types/*` 全局）+ `libReplacement: false`；本项目 `@types` 仅 6 个，收益中等。
+
+### TS 7.0.2 验证（已验证、未上线）
+
+- `tsc --noEmit`：**exit 0，0 错误**（与基线一致，无回归）。
+- `tsc -b`：exit 0，构建模式正常。
+- **`pnpm lint` 崩溃**：`@typescript-eslint/typescript-estree` 报 `Cannot read properties of undefined (reading 'Cjs')`——TS 7.0 Go 原生编译器内部 API 变更所致。
+- 阻塞 issue：[typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)，截至 2026-07-13 无兼容版本（含 canary `8.63.1-alpha.16`，peer 仍声明 `<6.1.0`）。
+
+### 下次升级（→ 7.0）checklist
+
+1. 确认 typescript-eslint 已发版支持 TS 7.0（订阅 #12518）。
+2. `pnpm add -D typescript@7`（6.0.3→7.0.2，Gate 2 已验证 0 错）。
+3. `pnpm lint` 不再崩溃 → 升 typescript-eslint 到支持版本。
+4. 用本文「复测方法」脚本测 7.0 性能，填回上方「升级后」列（预期 `tsc --noEmit` ~2–3s）。

--- a/docs/typescript-upgrade/ts7-upgrade-todo.md
+++ b/docs/typescript-upgrade/ts7-upgrade-todo.md
@@ -1,0 +1,172 @@
+# TypeScript 5.8.3 → 7.0 升级 TODO
+
+> 配套文档：[ts7-upgrade-baseline.md](./ts7-upgrade-baseline.md)（升级前基准数据）
+>
+> **升级路径**：推荐 `5.8 → 6.0 → 7.0`（经 6.0 过渡，可用 `ignoreDeprecations` 暴露弃用项）。
+> 若选择**直接跳 7.0**：跳过 Phase 1，但失去 `ignoreDeprecations` 安全网，所有问题会在 Gate 2 一次性暴露。
+
+## 阅读说明
+
+- 每个 Phase 末尾有 **Gate**（检查关卡）。
+- **⛔ Gate 不通过 = 禁止进入下一阶段**，需先修复或回滚（见文末 [回滚预案](#回滚预案)）。
+- 关键 Gate（Gate 2、Gate 4）专门拦截「升级后大量新增 TS 报错」「TS 跑不通」这两类情况。
+- 基线对照值（来自 baseline 文档）：`tsc --noEmit` 中位数 **22.49s**，类型错误数 **0**。
+
+---
+
+## Phase 0 — 准备
+
+- [ ] 确认基准已采集：[ts7-upgrade-baseline.md](./ts7-upgrade-baseline.md) 各指标已填
+- [ ] 从 `develop` 拉升级分支：`git checkout -b chore/upgrade-typescript-7`
+- [ ] 记录环境快照：TS `5.8.3` / Node `v20.19.0` / 后续全程锁定同一 Node 版本
+- [ ] 确认工作区干净：`git status` 无未提交改动
+- [ ] 关闭 VSCode 已打开的 TS 重型分析（减少干扰），准备好可随时 `git restore` 回退
+
+**Gate 0**
+- ✅ 基准文件完整、分支已建、工作区 clean
+- ⛔ 基准缺失或工作区脏 → 不开始
+
+---
+
+## Phase 1 — 过渡到 TS 6.0（暴露弃用项）
+
+> 目的：用 6.0 把“7.0 会变硬错误”的弃用项先暴露出来，借助 `ignoreDeprecations: "6.0"` 逐步修。
+
+- [ ] 安装 TS 6.0 最新版：`pnpm add -D typescript@~6.0`
+- [ ] 临时加 `"ignoreDeprecations": "6.0"`（仅过渡期，三个 tsconfig 都加）
+- [ ] 跑一次 `pnpm exec tsc --noEmit`，收集所有 deprecation 警告
+
+**移除已知硬阻塞项（TS 7.0 会直接报错）：**
+- [ ] 删除 [tsconfig.json](../../tsconfig.json) 的 `"baseUrl": "."`（保留 `paths`，无 baseUrl 时相对 tsconfig 目录解析）
+- [ ] 删除 [tsconfig.app.json](../../tsconfig.app.json) 的 `"baseUrl": "."`
+- [ ] 核对 `@/*` 别名仍生效（Vite 侧 [vite.config.ts](../../vite.config.ts) 独立配置，理论上不受影响——实测确认）
+
+**排查其它弃用项（本项目预计没有，但需确认）：**
+- [ ] 无 `importsNotUsedAsValues` / `preserveValueImports`（已用 `verbatimModuleSyntax` 替代 ✓）
+- [ ] 无 `outFile`
+- [ ] 无旧式 `moduleResolution`（已用 `bundler` ✓）
+
+- [ ] 全部弃用项解决后，**移除 `ignoreDeprecations: "6.0"`**，确认无新告警
+
+**Gate 1**
+- [ ] `pnpm exec tsc --noEmit` 退出码为 0
+- [ ] 错误数 = 基线 = **0**：`pnpm exec tsc --noEmit 2>&1 | grep -c "error TS"` 返回 0
+- [ ] 无 deprecation 告警：`pnpm exec tsc --noEmit 2>&1 | grep -i deprecat` 为空
+- [ ] `@/*` 别名在 typecheck 中正常解析
+- ⛔ 出现新错误或无法解决的弃用项 → 停在 6.0，不进 7.0；先逐条修复
+
+---
+
+## Phase 2 — 升级到 TS 7.0
+
+- [ ] 升级 TS：`pnpm add -D typescript@7`
+- [ ] 确认版本：`pnpm exec tsc --version` → `Version 7.x`
+- [ ] 跑全量类型检查：`pnpm exec tsc --noEmit`
+- [ ] 跑构建闸门：`pnpm exec tsc -b`（确认增量编译能跑通）
+
+**重点关注 TS 7.0 的破坏性变更：**
+- [ ] 类型级字符串工具（UTF-16 → 码点变更）是否产生新错误——本项目此前 grep 未发现此类用法，预计不受影响
+- [ ] 任何“诊断变严”导致的新错误，逐条确认是真实问题还是 TS 行为差异
+
+**Gate 2（关键关卡 — 拦截「大量新增报错 / TS 跑不通」）**
+- [ ] `pnpm exec tsc --noEmit` 退出码为 0
+- [ ] **错误数 = 基线 = 0**：`pnpm exec tsc --noEmit 2>&1 | grep -c "error TS"` 返回 0
+- [ ] `pnpm exec tsc -b` 成功（产出 `tsconfig.tsbuildinfo`，退出码 0）
+- ⛔ **大量新增 TS 报错** → 不要继续。先判断来源：
+  - 若是 UTF-16 字符串类型变更 → 修对应工具类型
+  - 若是推断变严 → 评估是否需 `// @ts-expect-error` 或补类型
+  - 无法快速解决 → **回滚到 Phase 1 的 6.0 状态**，分批迁移
+- ⛔ **`tsc -b` 跑不通 / 崩溃** → 回滚到 6.0，记录问题，等 TS 7.0 patch 版本
+
+---
+
+## Phase 3 — 生态工具适配
+
+> 这是本项目**最大的不确定性**：typescript-eslint 通过 TS 编译器 API 读 Program，需确认对 Go 原生编译器兼容。
+
+- [ ] 升级 typescript-eslint 到支持 TS 7.0 的版本（8.63.0+）：`pnpm add -D typescript-eslint@latest`
+- [ ] 跑全量 lint：`pnpm lint`（[package.json](../../package.json) → `eslint . --ext ts,tsx`）
+- [ ] 验证 `tsc-files`（lint-staged 在用）兼容性：手动 stage 一个 ts 文件，跑 `pnpm exec tsc-files --noEmit <file>` 看是否正常
+- [ ] 配置 VSCode 工作区使用项目 TS SDK：`.vscode/settings.json` 加 `"typescript.tsdk": "node_modules/typescript/lib"`，确认编辑器诊断与构建一致
+- [ ] 触发一次完整的 lint-staged（`git add` 一个文件后 commit 试跑）确认 pre-commit 钩子不报错
+
+**Gate 3**
+- [ ] `pnpm lint` 通过，无新增 lint 错误
+- [ ] `tsc-files` 能正常对单文件做类型检查
+- [ ] lint-staged / pre-commit 钩子跑通
+- [ ] VSCode 编辑器诊断与 `tsc` 一致（无“编辑器报错但构建不报”或反之）
+- ⛔ typescript-eslint 与 TS 7.0 不兼容（lint 报 unrelated 错）→ 暂时把 typescript-eslint 固定到兼容版本，或暂停升级等生态跟进
+- ⛔ tsc-files 崩溃 → lint-staged 中临时替换为别的方案或降级处理
+
+---
+
+## Phase 4 — 验证与性能复测
+
+- [ ] 端到端构建：`pnpm build` 成功，`dist/` 正常产出
+- [ ] 开发服务器：`pnpm dev` 能起，HMR 正常
+- [ ] 冒烟测试关键流程（手动）：
+  - [ ] 登录页
+  - [ ] 一个含表格 + 列控制的页面（如账号管理）
+  - [ ] 一个含复杂表单（RrhForm + Zod）的弹窗
+  - [ ] 一个含图表的报表页
+- [ ] 用 baseline 文档附录脚本复测性能，填入下表
+
+| 指标 | 升级前 | 升级后 | 倍率 |
+|---|---|---|---|
+| `tsc --noEmit` | 22.49s | _____ | __ |
+| `tsc -b` 冷 | 27.05s | _____ | __ |
+| `tsc -b` 热 | 23.27s | _____ | __ |
+| `pnpm build` 冷 | 39.31s | _____ | __ |
+| 类型错误数 | 0 | _____ | — |
+
+**Gate 4（关键关卡 — 拦截「构建/运行时回归」）**
+- [ ] `pnpm build` 退出码 0
+- [ ] `pnpm dev` 可正常启动与热更
+- [ ] 冒烟测试 4 个关键流程无运行时错误
+- [ ] 类型错误数仍 = 0
+- [ ] 性能：`tsc --noEmit` 明显快于 22.49s（若不升反降 → 异常，需排查）
+- ⛔ **构建失败** → 修；修不好回滚到 6.0
+- ⛔ **运行时崩 / 冒烟流程报错** → 排查（注意：vite 用 esbuild 转译，TS 版本理论上不影响产物；若确有差异，重点查 emit 相关配置）
+
+---
+
+## Phase 5 — 收尾
+
+- [ ] 更新 baseline 文档的「升级后」列与本文件的性能表
+- [ ] 清理过渡期产物（确认 `ignoreDeprecations` 已移除、无遗留临时配置）
+- [ ] 确认 `git status` 干净，改动均在升级分支
+- [ ] 开 PR，描述里贴「前/后性能对比表」与「关键检查结论」
+- [ ] （可选）若团队达成共识，更新 [CLAUDE.md](../../CLAUDE.md) 中的 TS 版本说明
+
+---
+
+## 回滚预案
+
+任意 Gate 反复无法通过时：
+
+1. **回滚依赖**：`git checkout develop -- package.json pnpm-lock.yaml && pnpm install`
+2. **回滚配置**：`git checkout develop -- tsconfig.json tsconfig.app.json tsconfig.node.json vite.config.ts`
+3. 确认 `pnpm exec tsc --noEmit` 恢复 0 错误、`pnpm build` 通过
+4. 把卡住的问题（哪一步、什么报错）记录到本文件末尾的「升级受阻日志」，留待后续版本重试
+
+## 升级受阻日志
+
+> （遇到 Gate 未通过时在此记录：阶段 / 现象 / 根因 / 处理，便于下次重试）
+
+### [已解决] Phase 1 / Gate 1 — TS 6.0 新增 `process` 报错
+
+- **阶段**：Phase 1，升级到 TS 6.0.3 后。
+- **现象**：`tsc --noEmit` 由基线 0 错误变为 1 错误：`src/i18n/i18n.ts(22,12): error TS2591: Cannot find name 'process'`。
+- **根因**：TS 6.0 不再为浏览器侧 tsconfig 自动注入 `@types/node` 的全局 `process`（5.8.3 会自动注入）。`i18n.ts` 用了 `process.env.NODE_ENV`。
+- **处理**：改用项目既有约定 `import.meta.env.DEV`（`tanstack-query.ts` 已在用 `import.meta.env.PROD`，`vite-env.d.ts` 已 reference `vite/client` 提供类型）。单行改动，语义等价，无需引 node 类型。
+- **结论**：Gate 1 通过，0 错误 / 0 弃用。该改动一并适用于 TS 7.0。
+
+### [暂停] Phase 3 / Gate 3 — typescript-eslint 不支持 TS 7.0
+
+- **阶段**：Phase 3，TS 7.0.2 + typescript-eslint 8.63.0。
+- **现象**：`pnpm lint` 崩溃，`TypeError: Cannot read properties of undefined (reading 'Cjs')` at `@typescript-eslint/typescript-estree/dist/create-program/shared.js`。
+- **根因**：TS 7.0 Go 原生编译器改变了内部 API，typescript-estree 读取 `ModuleKind.Cjs` 之类属性时为 `undefined`。typescript-eslint 全系（含 canary `8.63.1-alpha.16`）声明 peer `<6.1.0`，未支持 TS 7.0。
+- **处理**：经评估**暂停于 TS 6.0.3**（typecheck / lint / build / pre-commit 全绿），保留全部向前兼容改动；等 typescript-eslint 支持 7.0 后按「下次升级 checklist」一步升 7.0.2。
+- **跟踪**：[typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)。
+- **6.0.3 落点已验证**（Phase 4）：`pnpm build` exit 0（40s）、`pnpm dev` HTTP 200、`tsc-files` OK。详见 baseline 文档「升级结果记录」。
+- **6.0.3 相比 5.8.3 的得失**：typecheck -8%（20.66s vs 22.49s）、推断更准、7.0 就绪；唯一破坏性变更（`process` 报错）已修，无回归。利大于弊。

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tsc-files": "^1.1.3",
     "tw-animate-css": "^1.3.0",
-    "typescript": "~5.8.3",
-    "typescript-eslint": "^8.30.1",
+    "typescript": "~6.0.3",
+    "typescript-eslint": "^8.63.0",
     "vite": "^6.3.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
         version: 1.43.0
       i18next:
         specifier: ^25.2.1
-        version: 25.3.4(typescript@5.8.3)
+        version: 25.3.4(typescript@6.0.3)
       i18next-browser-languagedetector:
         specifier: ^8.1.0
         version: 8.2.0
@@ -184,7 +184,7 @@ importers:
         version: 7.62.0(react@19.1.1)
       react-i18next:
         specifier: ^15.5.2
-        version: 15.6.1(i18next@25.3.4(typescript@5.8.3))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3)
+        version: 15.6.1(i18next@25.3.4(typescript@6.0.3))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@6.0.3)
       react-pdf:
         specifier: ^10.4.1
         version: 10.4.1(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -227,7 +227,7 @@ importers:
         version: 9.33.0
       '@tanstack/eslint-plugin-query':
         specifier: ^5.78.0
-        version: 5.83.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
+        version: 5.83.1(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
       '@types/node':
         specifier: ^22.15.23
         version: 22.17.1
@@ -272,16 +272,16 @@ importers:
         version: 0.6.14(prettier@3.6.2)
       tsc-files:
         specifier: ^1.1.3
-        version: 1.1.4(typescript@5.8.3)
+        version: 1.1.4(typescript@6.0.3)
       tw-animate-css:
         specifier: ^1.3.0
         version: 1.3.6
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~6.0.3
+        version: 6.0.3
       typescript-eslint:
-        specifier: ^8.30.1
-        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
+        specifier: ^8.63.0
+        version: 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.17.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
@@ -597,8 +597,18 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/config-array@0.21.0':
@@ -1642,20 +1652,20 @@ packages:
   '@types/react@19.1.10':
     resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
 
-  '@typescript-eslint/eslint-plugin@8.39.1':
-    resolution: {integrity: sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==}
+  '@typescript-eslint/eslint-plugin@8.63.0':
+    resolution: {integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.39.1
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.63.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.39.1':
-    resolution: {integrity: sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==}
+  '@typescript-eslint/parser@8.63.0':
+    resolution: {integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.39.1':
     resolution: {integrity: sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==}
@@ -1663,8 +1673,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.63.0':
+    resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.39.1':
     resolution: {integrity: sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.63.0':
+    resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.39.1':
@@ -1673,15 +1693,25 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.39.1':
-    resolution: {integrity: sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==}
+  '@typescript-eslint/tsconfig-utils@8.63.0':
+    resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.63.0':
+    resolution: {integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@8.39.1':
     resolution: {integrity: sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.39.1':
@@ -1690,6 +1720,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.63.0':
+    resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@8.39.1':
     resolution: {integrity: sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1697,8 +1733,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.63.0':
+    resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.39.1':
     resolution: {integrity: sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@4.7.0':
@@ -1750,6 +1797,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
 
@@ -1758,6 +1809,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1877,6 +1932,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1957,6 +2021,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.33.0:
     resolution: {integrity: sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2012,6 +2080,15 @@ packages:
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2080,9 +2157,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2344,6 +2418,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2440,6 +2518,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -2707,6 +2789,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
@@ -2798,12 +2885,22 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -2824,15 +2921,15 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript-eslint@8.39.1:
-    resolution: {integrity: sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==}
+  typescript-eslint@8.63.0:
+    resolution: {integrity: sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3257,7 +3354,14 @@ snapshots:
       eslint: 9.33.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.33.0(jiti@2.5.1))':
+    dependencies:
+      eslint: 9.33.0(jiti@2.5.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.0':
     dependencies:
@@ -4257,9 +4361,9 @@ snapshots:
       tailwindcss: 4.1.11
       vite: 6.3.5(@types/node@22.17.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
-  '@tanstack/eslint-plugin-query@5.83.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@tanstack/eslint-plugin-query@5.83.1(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
       eslint: 9.33.0(jiti@2.5.1)
     transitivePeerDependencies:
       - supports-color
@@ -4346,41 +4450,49 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3))(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.39.1
-      '@typescript-eslint/type-utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.39.1
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/type-utils': 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.63.0
       eslint: 9.33.0(jiti@2.5.1)
-      graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.39.1
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.39.1
-      debug: 4.4.1
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
       eslint: 9.33.0(jiti@2.5.1)
-      typescript: 5.8.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.1(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.39.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.39.1
       debug: 4.4.1
-      typescript: 5.8.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.63.0
+      debug: 4.4.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4389,28 +4501,39 @@ snapshots:
       '@typescript-eslint/types': 8.39.1
       '@typescript-eslint/visitor-keys': 8.39.1
 
-  '@typescript-eslint/tsconfig-utils@8.39.1(typescript@5.8.3)':
+  '@typescript-eslint/scope-manager@8.63.0':
     dependencies:
-      typescript: 5.8.3
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
 
-  '@typescript-eslint/type-utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.39.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
-      debug: 4.4.1
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
+      debug: 4.4.3
       eslint: 9.33.0(jiti@2.5.1)
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.39.1': {}
 
-  '@typescript-eslint/typescript-estree@8.39.1(typescript@5.8.3)':
+  '@typescript-eslint/types@8.63.0': {}
+
+  '@typescript-eslint/typescript-estree@8.39.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.1(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.8.3)
+      '@typescript-eslint/project-service': 8.39.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.39.1
       '@typescript-eslint/visitor-keys': 8.39.1
       debug: 4.4.1
@@ -4418,19 +4541,45 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.33.0(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.39.1
       '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.39.1(typescript@6.0.3)
       eslint: 9.33.0(jiti@2.5.1)
-      typescript: 5.8.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.33.0(jiti@2.5.1))
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      eslint: 9.33.0(jiti@2.5.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4438,6 +4587,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.39.1
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@22.17.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
@@ -4486,6 +4640,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   blueimp-md5@2.19.0: {}
 
   brace-expansion@1.1.12:
@@ -4496,6 +4652,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4597,6 +4757,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   deep-is@0.1.4: {}
 
   dequal@2.0.3: {}
@@ -4679,6 +4843,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.33.0(jiti@2.5.1):
     dependencies:
@@ -4776,6 +4942,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4823,8 +4993,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphemer@1.4.0: {}
-
   has-flag@4.0.0: {}
 
   html-parse-stringify@3.0.1:
@@ -4839,11 +5007,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.2
 
-  i18next@25.3.4(typescript@5.8.3):
+  i18next@25.3.4(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.28.2
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
 
   ignore@5.3.2: {}
 
@@ -5035,6 +5203,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -5115,6 +5287,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pidtree@0.6.0: {}
 
   postcss@8.5.6:
@@ -5179,15 +5353,15 @@ snapshots:
     dependencies:
       react: 19.1.1
 
-  react-i18next@15.6.1(i18next@25.3.4(typescript@5.8.3))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3):
+  react-i18next@15.6.1(i18next@25.3.4(typescript@6.0.3))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.28.2
       html-parse-stringify: 3.0.1
-      i18next: 25.3.4(typescript@5.8.3)
+      i18next: 25.3.4(typescript@6.0.3)
       react: 19.1.1
     optionalDependencies:
       react-dom: 19.1.1(react@19.1.1)
-      typescript: 5.8.3
+      typescript: 6.0.3
 
   react-pdf@10.4.1(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -5309,6 +5483,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.8.5: {}
+
   set-cookie-parser@2.7.1: {}
 
   shebang-command@2.0.0:
@@ -5391,17 +5567,26 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@2.1.0(typescript@5.8.3):
+  ts-api-utils@2.1.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
 
-  tsc-files@1.1.4(typescript@5.8.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
+
+  tsc-files@1.1.4(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
@@ -5411,18 +5596,18 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3):
+  typescript-eslint@8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3))(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.33.0(jiti@2.5.1))(typescript@6.0.3)
       eslint: 9.33.0(jiti@2.5.1)
-      typescript: 5.8.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.8.3: {}
+  typescript@6.0.3: {}
 
   undici-types@6.21.0: {}
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -19,7 +19,7 @@ i18n
     },
     // When using language detector, we remove the explicit 'lng' setting
     fallbackLng: 'en',
-    debug: process.env.NODE_ENV === 'development',
+    debug: import.meta.env.DEV,
     detection: {
       // Order of detection methods
       order: ['localStorage', 'navigator', 'htmlTag', 'path', 'subdomain'],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
- typescript 5.8.3 → 6.0.3（最后一个 JS 编译器版本，为 7.0 铺路）
- typescript-eslint 8.30.1 → 8.63.0
- tsconfig: 移除 baseUrl（6.0 弃用、7.0 移除），保留 paths
- i18n: process.env.NODE_ENV → import.meta.env.DEV （6.0 不再自动注入 @types/node 全局；同时更符合浏览器/Vite 约定）
- 归档升级基准与 TODO 到 docs/typescript-upgrade/

TS 7.0.2 已验证 typecheck/tsc -b 0 错，但 typescript-eslint 尚不支持 TS 7.0（typescript-eslint#12518），故暂停于 6.0.3，待生态就绪再升。 6.0.3 实测 typecheck 较 5.8.3 提速约 8%（20.66s vs 22.49s）。